### PR TITLE
Make AntiKt.PseudoJet and HistoryElement immutable

### DIFF
--- a/antiktjl/Manifest.toml
+++ b/antiktjl/Manifest.toml
@@ -1,7 +1,115 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.1"
+julia_version = "1.8.2"
 manifest_format = "2.0"
-project_hash = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+project_hash = "1befd4eb863540f69fd02245341897f08d92e3e6"
 
-[deps]
+[[deps.Accessors]]
+deps = ["Compat", "CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "LinearAlgebra", "MacroTools", "Requires", "Test"]
+git-tree-sha1 = "eb7a1342ff77f4f9b6552605f27fd432745a53a3"
+uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+version = "0.1.22"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.Compat]]
+deps = ["Dates", "LinearAlgebra", "UUIDs"]
+git-tree-sha1 = "3ca828fe1b75fa84b021a7860bd039eaea84d2f2"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.3.0"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "0.5.2+0"
+
+[[deps.CompositionsBase]]
+git-tree-sha1 = "455419f7e328a1a2493cabc6428d79e951349769"
+uuid = "a33af91c-f02d-484b-be07-31d278c5ca2b"
+version = "0.1.1"
+
+[[deps.ConstructionBase]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "fb21ddd70a051d882a1686a5a550990bbe371a95"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.4.1"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "49510dfcb407e572524ba94aeae2fced1f3feb0f"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.8"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "42324d08725e200c23d4dfb549e0d5d89dede2d2"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.10"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.20+0"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.1.1+0"

--- a/antiktjl/Project.toml
+++ b/antiktjl/Project.toml
@@ -2,3 +2,6 @@ name = "AntiKt"
 uuid = "b1d79ec0-5126-4cc0-8710-7ce7530fd203"
 authors = ["Philippe Gras <philippe.gras@cern.ch>"]
 version = "0.1.0"
+
+[deps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/antiktjl/src/AntiKt.jl
+++ b/antiktjl/src/AntiKt.jl
@@ -28,6 +28,8 @@
 """
 module AntiKt
 
+using Accessors
+
 export PseudoJet, antikt
 
 include("pseudojet.jl")

--- a/antiktjl/src/antiktalgo.jl
+++ b/antiktjl/src/antiktalgo.jl
@@ -687,7 +687,7 @@ inclusive_jets(cs::ClusterSequence, ptmin = 0.) = begin
         elt.parent2 == BeamJet || continue
         iparent_jet = cs.history[elt.parent1].jetp_index
         jet = cs.jets[iparent_jet]
-        if jet.pt2 >= dcut
+        if jet._pt2 >= dcut
             push!(jets_local, jet)
         end
     end

--- a/antiktjl/src/pseudojet.jl
+++ b/antiktjl/src/pseudojet.jl
@@ -55,13 +55,14 @@ mutable struct PseudoJet<:FourMomentum
     _phi::Float64
     _pt2::Float64
     _inv_pt2::Float64
-    PseudoJet(px, py, pz, E) = begin
-        j = new(px, py, pz, E, 0, NaN, NaN)
-        j._pt2 = px*px +py*py
-        j._inv_pt2 = 1.0 / j._pt2
-        j
-    end
 end
+
+PseudoJet(px, py, pz, E) = begin
+    pt2 = px*px +py*py
+    inv_pt2 = inv(pt2)
+    PseudoJet(px, py, pz, E, 0, NaN, NaN, pt2, inv_pt2)
+end
+
 
 import Base.getproperty
 Base.getproperty(x::PseudoJet, sym::Symbol) = begin

--- a/antiktjl/src/pseudojet.jl
+++ b/antiktjl/src/pseudojet.jl
@@ -44,7 +44,7 @@ const _MaxRap = 1e5
 # \class PseudoJet
 # Class to contain pseudojets, including minimal information of use to
 # jet-clustering routines.
-mutable struct PseudoJet<:FourMomentum
+struct PseudoJet<:FourMomentum
     # construct a pseudojet from explicit components
     px::Float64
     py::Float64
@@ -64,7 +64,7 @@ PseudoJet(px, py, pz, E) = begin
 end
 
 
-set_momentum(j::PseudoJet, px, py, pz, E) = begin
+#=set_momentum(j::PseudoJet, px, py, pz, E) = begin
     j.px = px
     j.py = py
     j.pz = pz
@@ -73,7 +73,7 @@ set_momentum(j::PseudoJet, px, py, pz, E) = begin
     j._inv_pt2 = 1.0/j._pt2
     j._rap = NaN
     j._phi = NaN
-end
+end=#
 
 _fix_phi(phi::Real) = begin
     if phi < 0.0

--- a/antiktjl/src/pseudojet.jl
+++ b/antiktjl/src/pseudojet.jl
@@ -64,22 +64,6 @@ PseudoJet(px, py, pz, E) = begin
 end
 
 
-import Base.getproperty
-Base.getproperty(x::PseudoJet, sym::Symbol) = begin
-    if sym === :pt2
-        return x._pt2
-    elseif sym === :pt
-        return sqrt(x._pt2)
-    elseif sym == :rap
-        return _get_rap(x)
-    elseif sym == :phi
-        return _get_phi(x)
-    else
-        return getfield(x, sym)
-    end
-end
-
-
 set_momentum(j::PseudoJet, px, py, pz, E) = begin
     j.px = px
     j.py = py
@@ -126,11 +110,11 @@ end
 
 phi(p::PseudoJet) = phi_02pi(p)
 
-phi_02pi(p::PseudoJet) = p.phi
+phi_02pi(p::PseudoJet) = _get_phi(p)
 
-rap(p::PseudoJet) = p.rap
+rap(p::PseudoJet) = _get_rap(p)
 
-pt2(p::PseudoJet) = p.pt2
+pt2(p::PseudoJet) = p._pt2
 
 eta(p::PseudoJet) = p.rap
 

--- a/antiktjl/src/pseudojet.jl
+++ b/antiktjl/src/pseudojet.jl
@@ -51,8 +51,6 @@ struct PseudoJet<:FourMomentum
     pz::Float64
     E::Float64
     _cluster_hist_index::Int
-    _rap::Float64
-    _phi::Float64
     _pt2::Float64
     _inv_pt2::Float64
 end
@@ -60,7 +58,7 @@ end
 PseudoJet(px, py, pz, E) = begin
     pt2 = px*px +py*py
     inv_pt2 = inv(pt2)
-    PseudoJet(px, py, pz, E, 0, NaN, NaN, pt2, inv_pt2)
+    PseudoJet(px, py, pz, E, 0, pt2, inv_pt2)
 end
 
 


### PR DESCRIPTION
This turns `AntiKt.PseudoJet` and `HistoryElement` immutable. It doesn't speed up the algorithm itself, but reduces memory allocation significantly:

Before:

```julia
julia> @benchmark antikt.(events, R, ptmin)
BenchmarkTools.Trial: 160 samples with 1 evaluation.
 Range (min … max):  29.220 ms … 35.208 ms  ┊ GC (min … max): 0.00% … 11.49%
 Time  (median):     30.464 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   31.331 ms ±  1.620 ms  ┊ GC (mean ± σ):  4.11% ±  4.71%
```

After:

```julia
BenchmarkTools.Trial: 159 samples with 1 evaluation.
 Range (min … max):  30.142 ms … 37.150 ms  ┊ GC (min … max): 0.00% … 3.74%
 Time  (median):     31.688 ms              ┊ GC (median):    3.63%
 Time  (mean ± σ):   31.560 ms ±  1.001 ms  ┊ GC (mean ± σ):  2.02% ± 1.96%
```

The memory allocation cost of mutable structs is higher in Julia than in C++: An array of fixed-sized mutable structs is only a single memory allocation in C++, but in Julia, every element of the array must be allocated on the heap separately (this is true for pretty much any language with automatic garbage collection). "Small" structs should be immutable in Julia.

This becomes especially relevant when running on many threads, since threads can't do heap-(de-)allocation in parallel (both in Julia and C++, also Julia doesn't to parallel GC yet), so the alloc/gc-percentage goes up as the number of threads increases, until alloc/GC-cost dominates.

The remaining alloc/GC cost in `antikt` is mainly due to the mutable `TiledJet`. Using indices instead of pointers for `TiledJet`-references would make it possible to make `TiledJet` immutable as well, reducing GC cost to almost zero. `ArraysOfArrays.VectorOfArrays` could be used to reduce memory allocations for the vector-of-vectors-of-jets that `antikt` returns.

In general, using graph data structures based on adjacency lists (e.g. via Graphs.jl) would probably be better than using pointer/reference-based graph structures.